### PR TITLE
[🚀Deploy] 서버 본인 블락?

### DIFF
--- a/dbre_BE/settings/prod.py
+++ b/dbre_BE/settings/prod.py
@@ -2,7 +2,13 @@ from .base import *
 
 
 # ALLOWED_HOSTS = ["your.domain.com"]
-ALLOWED_HOSTS = ["desub.kr", "api.desub.kr", "www.api.desub.kr", "localhost"]
+ALLOWED_HOSTS = [
+    "desub.kr",
+    "api.desub.kr",
+    "www.api.desub.kr",
+    "localhost",
+    "223.130.134.137",
+]
 
 CSRF_COOKIE_HTTPONLY = False
 CSRF_COOKIE_SECURE = False


### PR DESCRIPTION
[2025-02-14 10:50:23,640] ERROR - django.security.DisallowedHost - Invalid HTTP_HOST header: '-'. You may need to add '-' to ALLOWED_HOSTS. 서버주소 '-'로 가림. 그냥 서버 주손데 이거 뭐임? 왜 서버 본인을 막음? 얼탱이 없네...