### PR TITLE
🔨Refactor : 빌링키 변경시 새로운 카드 정보 저장

### DIFF
--- a/payment/views.py
+++ b/payment/views.py
@@ -185,7 +185,7 @@ class UpdateBillingKeyView(APIView):
             if not scheduled_payments:
                 logger.info(f"기존 빌링키에 예약된 결제가 없음 빌링키만 업데이트")
                 billing_key_obj.billing_key = new_billing_key
-                billing_key_obj.save()
+                update_billing_key_info(billing_key_obj, new_billing_key)
 
                 serializer = BillingKeySerializer(billing_key_obj)
                 return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
기존 빌링키에 예약된 결제 정보 없으면 빌링키만 저장 하고 있는 문제 해결